### PR TITLE
Fixing deprecation errors

### DIFF
--- a/lib/SegmentedView.js
+++ b/lib/SegmentedView.js
@@ -1,8 +1,6 @@
 var React = require('react');
-
-var {
-    PropTypes
-} = React;
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 
 var {
     StyleSheet,
@@ -45,7 +43,7 @@ var styles = StyleSheet.create({
 });
 
 
-var SegmentedView = React.createClass({
+var SegmentedView = createReactClass({
 
     mixins: [tweenState.Mixin],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/lelandrichardson/react-native-segmented-view",
   "dependencies": {
-    "react-tween-state": "0.0.5"
+    "react-tween-state": "0.1.5"
   },
   "peerDependencies": {
     "react-native": ">=0.34.1"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "homepage": "https://github.com/lelandrichardson/react-native-segmented-view",
   "dependencies": {
+    "create-react-class": "^15.6.2",
+    "prop-types": "^15.6.0",
     "react-tween-state": "0.1.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
- Upgrades react-tween-state to 0.1.5 which has fixed errors stemming from the deprecation of `isMounted`
- Adds `prop-types` and `create-react-class` packages to quiet React's deprecation notice warnings